### PR TITLE
fix: pass quality parameter to openai-image provider

### DIFF
--- a/backend/internal/provider/openai_image.go
+++ b/backend/internal/provider/openai_image.go
@@ -61,6 +61,13 @@ func (p *OpenAIImageProvider) ValidateParams(params map[string]interface{}) erro
 		return fmt.Errorf("size 仅支持 auto、1024x1024、1024x1536、1536x1024")
 	}
 
+	quality, _ := params["quality"].(string)
+	switch strings.TrimSpace(strings.ToLower(quality)) {
+	case "", "auto", "low", "medium", "high":
+	default:
+		return fmt.Errorf("quality 仅支持 auto、low、medium、high")
+	}
+
 	return nil
 }
 
@@ -139,6 +146,9 @@ func (p *OpenAIImageProvider) buildImagesGenerationRequestBody(modelID string, p
 	}
 	if size, _ := params["size"].(string); strings.TrimSpace(size) != "" {
 		body.Size = strings.TrimSpace(strings.ToLower(size))
+	}
+	if quality, _ := params["quality"].(string); strings.TrimSpace(quality) != "" {
+		body.Quality = strings.TrimSpace(strings.ToLower(quality))
 	}
 	if count, ok := toInt(params["count"]); ok && count >= 1 && count <= 10 {
 		body.N = count


### PR DESCRIPTION
## **User description**
## 变更类型
- [x] Bug修复 (fix)

## 变更说明
前端在选择 `openai-image` provider 时会发送 `quality` 参数（auto/low/medium/high），但后端 `openai_image.go` 的 `buildImagesGenerationRequestBody` 从未读取该参数，导致 API 请求中 quality 始终为空。

本次修复：
- `buildImagesGenerationRequestBody`：从 `params["quality"]` 读取并设置到请求体
- `ValidateParams`：增加 quality 值的白名单校验（auto/low/medium/high）

## 验证
- `go vet ./internal/provider/...` 通过
- 直接调用 yunwu.ai `/v1/images/generations` 带 `quality: "low"` 返回 200 正常

## 检查清单
- [x] 代码遵循项目规范
- [x] 本地编译通过


___

## **CodeAnt-AI Description**
**OpenAI image requests now send the selected quality and reject invalid values**

### What Changed
- OpenAI image generation now includes the chosen `quality` setting instead of leaving it empty
- `quality` is now checked before sending, and only `auto`, `low`, `medium`, or `high` are accepted
- Invalid `quality` values now fail immediately with a clear error

### Impact
`✅ Correct image quality in generated images`
`✅ Fewer failed image requests`
`✅ Clearer image generation errors`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?id=oEm3zF-DYb5oN05nhZFa1UJEcCOqC3knawJdwP3Y9Ik&org=ShellMonster)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
